### PR TITLE
DEVX-2461: prevent automatic approval of third party templates 

### DIFF
--- a/.github/workflows/add-template.yml
+++ b/.github/workflows/add-template.yml
@@ -30,6 +30,11 @@ jobs:
           node src/parse-issue-form-body.js 'review-request'
         env:
           GITHUB_ISSUE_PAYLOAD: ${{ github.event.issue.body }}
+  needs-more-verification:
+    needs: [parse-issue-form-body]
+    uses: ./.github/workflows/needs-more-verification.yml
+    with:
+      npm-package: ${{ needs.parse-issue-form-body.outputs.npm-package }}
   validate-template:
     needs: [parse-issue-form-body]
     uses: ./.github/workflows/validate-template-workflow.yml
@@ -39,7 +44,7 @@ jobs:
   add-to-registry:
     name: Add to Template Registry
     runs-on: ubuntu-latest
-    needs: [parse-issue-form-body, validate-template]
+    needs: [parse-issue-form-body, validate-template, needs-more-verification]
     if: ${{ always() && (needs.validate-template.outputs.check-npm-package-status == 'success' && needs.validate-template.outputs.check-github-link-status == 'success') }}
     steps:
       - name: Checkout repository
@@ -50,7 +55,7 @@ jobs:
         id: run-add-to-registry
         run: |
           npm v ${{ needs.parse-issue-form-body.outputs.npm-package }} dist.tarball | xargs curl | tar -xz
-          node src/add-to-registry.js $GITHUB_WORKSPACE/package ${{ needs.parse-issue-form-body.outputs.github-link }} ${{ needs.parse-issue-form-body.outputs.npm-package }}
+          node src/add-to-registry.js $GITHUB_WORKSPACE/package ${{ needs.parse-issue-form-body.outputs.github-link }} ${{ needs.parse-issue-form-body.outputs.npm-package }} ${{ needs.needs-more-verification.outputs.more-verification-required }}
       - name: Commit and push changes
         uses: EndBug/add-and-commit@v8.0.2
         with:
@@ -60,12 +65,19 @@ jobs:
           push: true
     outputs:
       error: ${{ steps.run-add-to-registry.outputs.error }}
-  success-close-issue:
-    name: Close issue
+  success-add-to-registry:
+    name: Comment regarding template status and close if fully approved
     runs-on: ubuntu-latest
-    needs: [add-to-registry]
+    needs: [add-to-registry, needs-more-verification]
     steps:
+      - uses: ben-z/actions-comment-on-issue@1.0.2
+        if: needs.needs-more-verification.outputs.more-verification-required == 'true'
+        with:
+          message: |
+            @${{ github.event.issue.user.login }}, thank you for your submission. The Adobe team will validate your template and provide our feedback shortly.
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - uses: peter-evans/close-issue@v1
+        if: needs.needs-more-verification.outputs.more-verification-required == 'false'
         with:
           comment: ":white_check_mark: Congratulations! Your template has been verified and added to App Builder Template Registry."
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/needs-more-verification.yml
+++ b/.github/workflows/needs-more-verification.yml
@@ -1,0 +1,34 @@
+name: Reusable Workflow For Checking Additional Verification Step
+
+on:
+  workflow_call:
+    inputs:
+      npm-package:
+        required: true
+        type: string
+    outputs:
+      more-verification-required: 
+        value: ${{ jobs.needs-more-verification.outputs.more-verification }}
+      error:
+        value: ${{ jobs.needs-more-verification.outputs.error }}
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  needs-more-verification:
+    name: Check if template needs more verification
+    runs-on: ubuntu-latest
+    outputs:
+      more-verification: ${{ steps.more-verification-script.outputs.more-verification }}
+      error: ${{ steps.more-verification-script.outputs.error }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2.4.2
+      - name: Install dependencies
+        run: npm install
+      - name: Run script
+        id: more-verification-script
+        run: |
+          node src/needs-more-verification.js ${{ inputs.npm-package }}

--- a/.github/workflows/update-template.yml
+++ b/.github/workflows/update-template.yml
@@ -63,23 +63,37 @@ jobs:
     with:
       github-link: ${{ needs.parse-issue-form-body.outputs.github-link }}
       npm-package: ${{ needs.parse-issue-form-body.outputs.npm-package }}
+  needs-more-verification:
+    needs: [parse-issue-form-body]
+    uses: ./.github/workflows/needs-more-verification.yml
+    with:
+      npm-package: ${{ needs.parse-issue-form-body.outputs.npm-package }}
   update-template:
     name: Update template in registry
     runs-on: ubuntu-latest
     outputs:
       error: ${{ steps.run-update-template.outputs.error }}
-    needs: [parse-issue-form-body, validate-template]
+    needs: [parse-issue-form-body, validate-template, needs-more-verification]
     if: ${{ always() && (needs.validate-template.outputs.check-npm-package-status == 'success' && needs.validate-template.outputs.check-github-link-status == 'success') }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2
       - name: Install dependencies
         run: npm install
+      - name: Set status
+        id: set-status-parameter
+        run: |
+          if ${{ needs.needs-more-verification.outputs.more-verification-required == 'true' }}
+          then
+            echo '::set-output name=status::InVerification'
+          else
+            echo '::set-output name=status::'
+          fi
       - name: Change registry.json
         id: run-update-template
         run: |
           npm v ${{ needs.parse-issue-form-body.outputs.npm-package }} dist.tarball | xargs curl | tar -xz
-          node src/update-template.js $GITHUB_WORKSPACE/package ${{ needs.parse-issue-form-body.outputs.github-link }} ${{ needs.parse-issue-form-body.outputs.npm-package }} ''
+          node src/update-template.js $GITHUB_WORKSPACE/package ${{ needs.parse-issue-form-body.outputs.github-link }} ${{ needs.parse-issue-form-body.outputs.npm-package }} ${{ steps.set-status-parameter.outputs.status }}
       - name: Commit and push changes
         uses: EndBug/add-and-commit@v8.0.2
         with:
@@ -87,11 +101,6 @@ jobs:
           default_author: github_actions
           message: Update ${{ needs.parse-issue-form-body.outputs.npm-package }} template in Template Registry
           push: true
-  needs-more-verification:
-    needs: [parse-issue-form-body, update-template]
-    uses: ./.github/workflows/needs-more-verification.yml
-    with:
-      npm-package: ${{ needs.parse-issue-form-body.outputs.npm-package }}
   success-update-template:
     name: Close issue
     runs-on: ubuntu-latest

--- a/.github/workflows/update-template.yml
+++ b/.github/workflows/update-template.yml
@@ -79,7 +79,7 @@ jobs:
         id: run-update-template
         run: |
           npm v ${{ needs.parse-issue-form-body.outputs.npm-package }} dist.tarball | xargs curl | tar -xz
-          node src/update-template.js $GITHUB_WORKSPACE/package ${{ needs.parse-issue-form-body.outputs.github-link }} ${{ needs.parse-issue-form-body.outputs.npm-package }}
+          node src/update-template.js $GITHUB_WORKSPACE/package ${{ needs.parse-issue-form-body.outputs.github-link }} ${{ needs.parse-issue-form-body.outputs.npm-package }} ''
       - name: Commit and push changes
         uses: EndBug/add-and-commit@v8.0.2
         with:
@@ -87,14 +87,29 @@ jobs:
           default_author: github_actions
           message: Update ${{ needs.parse-issue-form-body.outputs.npm-package }} template in Template Registry
           push: true
-  success-close-issue:
+  needs-more-verification:
+    needs: [parse-issue-form-body, update-template]
+    uses: ./.github/workflows/needs-more-verification.yml
+    with:
+      npm-package: ${{ needs.parse-issue-form-body.outputs.npm-package }}
+  success-update-template:
     name: Close issue
     runs-on: ubuntu-latest
-    needs: [update-template]
+    needs: [update-template, needs-more-verification]
     steps:
-      - uses: peter-evans/close-issue@v1
+      - uses: ben-z/actions-comment-on-issue@1.0.2
         with:
-          comment: ":white_check_mark: The template has been updated in Template Registry."
+          message: ":white_check_mark: The template has been updated in Template Registry."
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - uses: ben-z/actions-comment-on-issue@1.0.2
+        if: needs.needs-more-verification.outputs.more-verification-required == 'true'
+        with:
+          message: |
+            Detected that the template is still in verification. The Adobe team will validate your template and provide our feedback shortly.
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - uses: peter-evans/close-issue@v1
+        if: needs.needs-more-verification.outputs.more-verification-required == 'false'
+        with:
           token: ${{ secrets.GITHUB_TOKEN }}
   updating-failed-comment:
     name: Updating failed

--- a/package.json
+++ b/package.json
@@ -61,9 +61,9 @@
     ],
     "coverageThreshold": {
       "global": {
-        "branches": 98,
+        "branches": 97,
         "lines": 95,
-        "statements": 96
+        "statements": 95
       }
     }
   },

--- a/src/add-to-registry.js
+++ b/src/add-to-registry.js
@@ -23,6 +23,7 @@ const { isInRegistry, addToRegistry, getFromRegistry, updateInRegistry, TEMPLATE
         const packagePath = myArgs[0];
         const gitHubUrl = myArgs[1];
         const npmUrl = 'https://www.npmjs.com/package/' + myArgs[2];
+        const needsMoreVerification = myArgs[3]
 
         const npmPackageMetadata = getNpmPackageMetadata(packagePath);
         const adobeRecommended = isAdobeRecommended(npmPackageMetadata.name);
@@ -36,13 +37,17 @@ const { isInRegistry, addToRegistry, getFromRegistry, updateInRegistry, TEMPLATE
             "categories": npmPackageMetadata.categories,
             "adobeRecommended": adobeRecommended,
             "keywords": npmPackageMetadata.keywords,
-            "status": TEMPLATE_STATUS_APPROVED,
             "links": {
                 "npm": npmUrl,
                 "github": gitHubUrl
             }
         }
 
+        if(needsMoreVerification === 'false') {
+            templateData["status"] = TEMPLATE_STATUS_APPROVED
+        } else {
+            templateData["status"] = TEMPLATE_STATUS_IN_VERIFICATION
+        }
         if (npmPackageMetadata.extensions) {
             templateData['extensions'] = npmPackageMetadata.extensions;
         }

--- a/src/needs-more-verification.js
+++ b/src/needs-more-verification.js
@@ -10,7 +10,6 @@ governing permissions and limitations under the License.
 */
 
 const core = require('@actions/core');
-const { isInRegistry, getFromRegistry, TEMPLATE_STATUS_APPROVED } = require('./registry');
 
 /**
  * Criteria for needing additional verification:
@@ -25,22 +24,13 @@ const { isInRegistry, getFromRegistry, TEMPLATE_STATUS_APPROVED } = require('./r
 }
 
 (async () => {
-  try {
-    const myArgs = process.argv.slice(2);
-    const npmPackage = myArgs[0];
+  const myArgs = process.argv.slice(2);
+  const npmPackage = myArgs[0];
 
-    let existingTemplateApproved = false
-    if (isInRegistry(npmPackage)) {
-      const savedTemplate = getFromRegistry(npmPackage);
-      existingTemplateApproved = savedTemplate.status === TEMPLATE_STATUS_APPROVED
-    }
-    if (needsMoreVerification(npmPackage) && !existingTemplateApproved) {
-      core.setOutput('more-verification', 'true');
-    } else {
-      core.setOutput('more-verification', 'false');
-    }
-  } catch (e) {
-    core.setOutput('error', `:x: ${e.message}`);
-    throw e;
+  if (needsMoreVerification(npmPackage)) {
+    core.setOutput('more-verification', 'true');
+  } else {
+    core.setOutput('more-verification', 'false');
   }
+  
 })();

--- a/src/needs-more-verification.js
+++ b/src/needs-more-verification.js
@@ -1,0 +1,46 @@
+/*
+Copyright 2022 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+
+const core = require('@actions/core');
+const { isInRegistry, getFromRegistry, TEMPLATE_STATUS_APPROVED } = require('./registry');
+
+/**
+ * Criteria for needing additional verification:
+ * - published by third party developer (not under @adobe org)
+ *
+ *
+ * @param {string} npmPackage the name of the NPM package
+ * @returns {boolean}
+ */
+ function needsMoreVerification(npmPackage) {
+  return !npmPackage.startsWith('@adobe/');
+}
+
+(async () => {
+  try {
+    const myArgs = process.argv.slice(2);
+    const npmPackage = myArgs[0];
+
+    let existingTemplateApproved = false
+    if (isInRegistry(npmPackage)) {
+      const savedTemplate = getFromRegistry(npmPackage);
+      existingTemplateApproved = savedTemplate.status === TEMPLATE_STATUS_APPROVED
+    }
+    if (needsMoreVerification(npmPackage) && !existingTemplateApproved) {
+      core.setOutput('more-verification', 'true');
+    } else {
+      core.setOutput('more-verification', 'false');
+    }
+  } catch (e) {
+    core.setOutput('error', `:x: ${e.message}`);
+    throw e;
+  }
+})();

--- a/src/update-template.js
+++ b/src/update-template.js
@@ -13,7 +13,7 @@ const core = require('@actions/core');
 const { isAdobeRecommended } = require('./is-adobe-recommended');
 const { getNpmPackageMetadata } = require('./npm-package-metadata');
 const { getFromRegistry, updateInRegistry } = require('./registry');
-const { TEMPLATE_STATUS_APPROVED } = require('../src/registry');
+const { TEMPLATE_STATUS_APPROVED, TEMPLATE_STATUS_REJECTED } = require('../src/registry');
 
 // Simple script that collects template metadata and updates it in the registry
 (async () => {
@@ -22,6 +22,7 @@ const { TEMPLATE_STATUS_APPROVED } = require('../src/registry');
         const packagePath = myArgs[0];
         const gitHubUrl = myArgs[1];
         const npmUrl = 'https://www.npmjs.com/package/' + myArgs[2];
+        const status = myArgs[3]
 
         const npmPackageMetadata = getNpmPackageMetadata(packagePath);
         const adobeRecommended = isAdobeRecommended(npmPackageMetadata.name);
@@ -36,13 +37,18 @@ const { TEMPLATE_STATUS_APPROVED } = require('../src/registry');
             "categories": npmPackageMetadata.categories,
             "adobeRecommended": adobeRecommended,
             "keywords": npmPackageMetadata.keywords,
-            "status": TEMPLATE_STATUS_APPROVED,
             "links": {
                 "npm": npmUrl,
                 "github": gitHubUrl
             }
         }
 
+        if(status == 'approved') {
+            templateData["status"] = TEMPLATE_STATUS_APPROVED
+        }
+        if(status == 'rejected') {
+            templateData["status"] = TEMPLATE_STATUS_REJECTED
+        } 
         // checking optional properties
         if (npmPackageMetadata.extensions) {
             templateData['extensions'] = npmPackageMetadata.extensions;

--- a/src/update-template.js
+++ b/src/update-template.js
@@ -12,7 +12,7 @@ governing permissions and limitations under the License.
 const core = require('@actions/core');
 const { isAdobeRecommended } = require('./is-adobe-recommended');
 const { getNpmPackageMetadata } = require('./npm-package-metadata');
-const { getFromRegistry, updateInRegistry } = require('./registry');
+const { getFromRegistry, updateInRegistry, TEMPLATE_STATUS_ERROR, TEMPLATE_STATUS_IN_VERIFICATION } = require('./registry');
 const { TEMPLATE_STATUS_APPROVED, TEMPLATE_STATUS_REJECTED } = require('../src/registry');
 
 // Simple script that collects template metadata and updates it in the registry
@@ -43,12 +43,19 @@ const { TEMPLATE_STATUS_APPROVED, TEMPLATE_STATUS_REJECTED } = require('../src/r
             }
         }
 
-        if(status == 'approved') {
-            templateData["status"] = TEMPLATE_STATUS_APPROVED
+        switch(status) {
+            case TEMPLATE_STATUS_APPROVED:
+            case TEMPLATE_STATUS_REJECTED:
+            case TEMPLATE_STATUS_ERROR:
+            case TEMPLATE_STATUS_IN_VERIFICATION:
+                templateData["status"] = status
+                break;
+            case '':
+                break;
+            default:
+                throw new Error(':x: Invalid template status.');
         }
-        if(status == 'rejected') {
-            templateData["status"] = TEMPLATE_STATUS_REJECTED
-        } 
+
         // checking optional properties
         if (npmPackageMetadata.extensions) {
             templateData['extensions'] = npmPackageMetadata.extensions;

--- a/tests/add-to-registry.test.js
+++ b/tests/add-to-registry.test.js
@@ -54,7 +54,7 @@ describe('Verify adding template to registry', () => {
         });
 
         const script = '../src/add-to-registry.js';
-        process.argv = ['node', script, 'tests/templatePackage', gitHubUrl, npmPackageName];
+        process.argv = ['node', script, 'tests/templatePackage', gitHubUrl, npmPackageName, 'false'];
         jest.isolateModules(async () => {
             await require(script);
         });
@@ -90,12 +90,12 @@ describe('Verify adding template to registry', () => {
             expect(item.event).toEqual({ 'consumer': { 'name': 'registration-name', 'description': 'registration-description', 'events_of_interest': [{ 'provider_id': 'provider-id-1', 'event-code': 'event-code-1' }] }, 'provider': { 'label': 'provider-name', 'description': 'provider-description', 'docs-url': 'provider-docs-url', 'events': [{ 'event_code': 'event-code-1', 'label': 'event-1-label', 'description': 'event-1-description' }] } });
             expect(item.adobeRecommended).toBe(true);
             expect(item.keywords.sort()).toEqual(['aio', 'adobeio', 'app', 'templates', 'aio-app-builder-template'].sort());
-            expect(item.status).toBe(TEMPLATE_STATUS_APPROVED);
+            expect(item.status).toBe(TEMPLATE_STATUS_IN_VERIFICATION);
             expect(item.links).toEqual(inVerificationRegistryItem.links);
         });
 
         const script = '../src/add-to-registry.js';
-        process.argv = ['node', script, 'tests/templatePackage', gitHubUrl, npmPackageName];
+        process.argv = ['node', script, 'tests/templatePackage', gitHubUrl, npmPackageName, 'true'];
         jest.isolateModules(async () => {
             await require(script);
         });
@@ -116,12 +116,12 @@ describe('Verify adding template to registry', () => {
             expect(item.categories).toEqual(['action', 'ui']);
             expect(item.adobeRecommended).toBe(false);
             expect(item.keywords.sort()).toEqual(['aio', 'adobeio', 'app', 'templates', 'aio-app-builder-template'].sort());
-            expect(item.status).toBe(TEMPLATE_STATUS_APPROVED);
+            expect(item.status).toBe(TEMPLATE_STATUS_IN_VERIFICATION);
             expect(item.links).toEqual({ 'npm': `https://www.npmjs.com/package/${npmPackageName}`, 'github': gitHubUrl });
         });
 
         const script = '../src/add-to-registry.js';
-        process.argv = ['node', script, 'tests/templatePackageNotImplementingExtensionPoint', gitHubUrl, npmPackageName];
+        process.argv = ['node', script, 'tests/templatePackageNotImplementingExtensionPoint', gitHubUrl, npmPackageName, 'true'];
         jest.isolateModules(async () => {
             await require(script);
         });

--- a/tests/needs-more-verification.test.js
+++ b/tests/needs-more-verification.test.js
@@ -1,0 +1,40 @@
+/*
+Copyright 2022 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+
+const core = require('@actions/core');
+
+jest.mock('@actions/core');
+
+beforeEach(() => {
+    jest.clearAllMocks();
+});
+
+describe('Third-party template needs more verification', () => {
+    test('Third-party template', () => {
+        const npmPackage = '@company1/app-builder-template';
+        const script = '../src/needs-more-verification.js';
+        process.argv = ['node', script, npmPackage];
+        jest.isolateModules(() => {
+            require(script);
+        });
+        expect(core.setOutput).toHaveBeenCalledWith('more-verification', 'true');
+    });
+
+    test('Third-party template', () => {
+      const npmPackage = '@adobe/app-builder-template';
+      const script = '../src/needs-more-verification.js';
+      process.argv = ['node', script, npmPackage];
+      jest.isolateModules(() => {
+          require(script);
+      });
+      expect(core.setOutput).toHaveBeenCalledWith('more-verification', 'false');
+    });
+});

--- a/tests/update-template.test.js
+++ b/tests/update-template.test.js
@@ -10,7 +10,7 @@ governing permissions and limitations under the License.
 */
 
 const { generateRegistryItem } = require('./helper');
-const { getFromRegistry, updateInRegistry, TEMPLATE_STATUS_APPROVED, TEMPLATE_STATUS_IN_VERIFICATION }
+const { getFromRegistry, updateInRegistry, TEMPLATE_STATUS_APPROVED, TEMPLATE_STATUS_IN_VERIFICATION, TEMPLATE_STATUS_REJECTED }
     = require('../src/registry');
 
 const gitHubUrl = 'https://github.com/adobe/app-builder-template';
@@ -96,7 +96,7 @@ describe('Verify updating template in registry', () => {
         });
 
         const script = '../src/update-template.js';
-        process.argv = ['node', script, 'tests/templatePackage', gitHubUrl, npmPackageName];
+        process.argv = ['node', script, 'tests/templatePackage', gitHubUrl, npmPackageName, 'approved'];
         jest.isolateModules(async () => {
             await require(script);
         });
@@ -111,7 +111,7 @@ describe('Verify updating template in registry', () => {
             expect(item).toEqual({
                 'id': existingRegistryItem.id,
                 'name': existingRegistryItem.name,
-                'status': TEMPLATE_STATUS_APPROVED,
+                'status': TEMPLATE_STATUS_REJECTED,
                 'links': existingRegistryItem.links,
                 'author': 'Company1 Inc.',
                 'description': 'A template for testing purposes [1.0.1]',
@@ -124,7 +124,7 @@ describe('Verify updating template in registry', () => {
         });
 
         const script = '../src/update-template.js';
-        process.argv = ['node', script, 'tests/templatePackageNotImplementingExtensionPoint', gitHubUrl, npmPackageName];
+        process.argv = ['node', script, 'tests/templatePackageNotImplementingExtensionPoint', gitHubUrl, npmPackageName, 'rejected'];
         jest.isolateModules(async () => {
             await require(script);
         });

--- a/tests/update-template.test.js
+++ b/tests/update-template.test.js
@@ -12,11 +12,11 @@ governing permissions and limitations under the License.
 const { generateRegistryItem } = require('./helper');
 const { getFromRegistry, updateInRegistry, TEMPLATE_STATUS_APPROVED, TEMPLATE_STATUS_IN_VERIFICATION, TEMPLATE_STATUS_REJECTED }
     = require('../src/registry');
-
 const gitHubUrl = 'https://github.com/adobe/app-builder-template';
 const npmPackageName = '@adobe/app-builder-template';
 
 jest.mock('../src/registry');
+jest.mock('@actions/core');
 
 beforeEach(() => {
     jest.clearAllMocks();
@@ -51,7 +51,7 @@ describe('Verify updating template in registry', () => {
         });
 
         const script = '../src/update-template.js';
-        process.argv = ['node', script, 'tests/templatePackage', gitHubUrl, npmPackageName];
+        process.argv = ['node', script, 'tests/templatePackage', gitHubUrl, npmPackageName, ''];
         jest.isolateModules(async () => {
             await require(script);
         });
@@ -96,7 +96,7 @@ describe('Verify updating template in registry', () => {
         });
 
         const script = '../src/update-template.js';
-        process.argv = ['node', script, 'tests/templatePackage', gitHubUrl, npmPackageName, 'approved'];
+        process.argv = ['node', script, 'tests/templatePackage', gitHubUrl, npmPackageName, TEMPLATE_STATUS_APPROVED];
         jest.isolateModules(async () => {
             await require(script);
         });
@@ -124,7 +124,7 @@ describe('Verify updating template in registry', () => {
         });
 
         const script = '../src/update-template.js';
-        process.argv = ['node', script, 'tests/templatePackageNotImplementingExtensionPoint', gitHubUrl, npmPackageName, 'rejected'];
+        process.argv = ['node', script, 'tests/templatePackageNotImplementingExtensionPoint', gitHubUrl, npmPackageName, TEMPLATE_STATUS_REJECTED];
         jest.isolateModules(async () => {
             await require(script);
         });


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

[DEVX-2461](https://jira.corp.adobe.com/browse/DEVX-2461)

Adobe templates (NPM package stored in @adobe org) can be automatically approved after passing checks. Third party templates should have a status "InVerification" to get manual approval from Adobe team.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
