### PR TITLE
Remove adobe recommended flag from registry which are still in development

### DIFF
--- a/registry.json
+++ b/registry.json
@@ -198,7 +198,7 @@
             "action",
             "ui"
         ],
-        "adobeRecommended": true,
+        "adobeRecommended": false,
         "keywords": [
             "ecosystem:aio-app-builder-templates"
         ],


### PR DESCRIPTION


## Description

This template is still under development and we want to avoid recommend using it by 3rd party developers


## Motivation and Context
This template is still under development and we want to avoid recommend using it by 3rd party developers


## How Has This Been Tested?
 no testing is required, for now, the change should only affect configuration



## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
This template is still under development and we want to avoid recommend using it by 3rd party developers


- [ ] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
