### PR TITLE
Fix failing Jest tests

### DIFF
--- a/tests/registry.test.js
+++ b/tests/registry.test.js
@@ -15,7 +15,13 @@ const { when } = require('jest-when');
 const fs = require('fs');
 const registry = require('../src/registry');
 
-jest.mock('fs');
+jest.mock('fs', () => ({
+    promises: {
+      access: jest.fn()
+    },
+    readFileSync: jest.fn(),
+    writeFileSync: jest.fn(),
+  }));
 when(fs.readFileSync).calledWith('registry.schema.json').mockReturnValue(getRegistryJsonSchema());
 
 beforeEach(() => {

--- a/tests/remove-from-registry.test.js
+++ b/tests/remove-from-registry.test.js
@@ -14,7 +14,13 @@ const { when } = require('jest-when');
 const { generateRegistryItem, getRegistryJsonSchema } = require('./helper');
 const fs = require('fs');
 
-jest.mock('fs');
+jest.mock('fs', () => ({
+    promises: {
+      access: jest.fn()
+    },
+    readFileSync: jest.fn(),
+    writeFileSync: jest.fn(),
+  }));
 
 beforeEach(() => {
     jest.clearAllMocks();


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Some Jest tests were failing because of this error
```
Test suite failed to run

    TypeError: Cannot destructure property 'access' of 'fs_1.promises' as it is undefined.

      at Object.<anonymous> (node_modules/@actions/core/lib/summary.js:45:3)
      at Object.<anonymous> (node_modules/@actions/core/lib/core.js:429:17)
```

Found the solution here: https://github.com/actions/toolkit/issues/1075

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

`npm run test`

https://github.com/devx-services/aio-template-submission/actions/runs/3253266427/jobs/5340369197

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
