### PR TITLE
DEVX-2701: adobeRecommended flag is overriden during scheduled template registry verification

### DIFF
--- a/src/update-template.js
+++ b/src/update-template.js
@@ -10,7 +10,6 @@ governing permissions and limitations under the License.
 */
 
 const core = require('@actions/core');
-const { isAdobeRecommended } = require('./is-adobe-recommended');
 const { getNpmPackageMetadata } = require('./npm-package-metadata');
 const { getFromRegistry, updateInRegistry, TEMPLATE_STATUS_ERROR, TEMPLATE_STATUS_IN_VERIFICATION } = require('./registry');
 const { TEMPLATE_STATUS_APPROVED, TEMPLATE_STATUS_REJECTED } = require('../src/registry');

--- a/src/update-template.js
+++ b/src/update-template.js
@@ -25,7 +25,6 @@ const { TEMPLATE_STATUS_APPROVED, TEMPLATE_STATUS_REJECTED } = require('../src/r
         const status = myArgs[3]
 
         const npmPackageMetadata = getNpmPackageMetadata(packagePath);
-        const adobeRecommended = isAdobeRecommended(npmPackageMetadata.name);
 
         const savedTemplate = getFromRegistry(npmPackageMetadata.name);
 
@@ -35,7 +34,6 @@ const { TEMPLATE_STATUS_APPROVED, TEMPLATE_STATUS_REJECTED } = require('../src/r
             "description": npmPackageMetadata.description,
             "latestVersion": npmPackageMetadata.version,
             "categories": npmPackageMetadata.categories,
-            "adobeRecommended": adobeRecommended,
             "keywords": npmPackageMetadata.keywords,
             "links": {
                 "npm": npmUrl,

--- a/tests/helper.js
+++ b/tests/helper.js
@@ -55,7 +55,6 @@ function generateRegistryItem(templateName, templateStatus = TEMPLATE_STATUS_APP
                     }
                 ],
                 'event': { 'consumer': { 'name': 'registration-name', 'description': 'registration-description', 'events_of_interest': [{ 'provider_id': 'provider-id-1', 'event-code': 'event-code-1' }] }, 'provider': { 'label': 'provider-name', 'description': 'provider-description', 'docs-url': 'provider-docs-url', 'events': [{ 'event_code': 'event-code-1', 'label': 'event-1-label', 'description': 'event-1-description' }] } },
-                'adobeRecommended': true,
                 'keywords': [
                     'aio',
                     'adobeio',

--- a/tests/helper.js
+++ b/tests/helper.js
@@ -55,6 +55,7 @@ function generateRegistryItem(templateName, templateStatus = TEMPLATE_STATUS_APP
                     }
                 ],
                 'event': { 'consumer': { 'name': 'registration-name', 'description': 'registration-description', 'events_of_interest': [{ 'provider_id': 'provider-id-1', 'event-code': 'event-code-1' }] }, 'provider': { 'label': 'provider-name', 'description': 'provider-description', 'docs-url': 'provider-docs-url', 'events': [{ 'event_code': 'event-code-1', 'label': 'event-1-label', 'description': 'event-1-description' }] } },
+                'adobeRecommended': true,
                 'keywords': [
                     'aio',
                     'adobeio',

--- a/tests/update-template.test.js
+++ b/tests/update-template.test.js
@@ -57,6 +57,42 @@ describe('Verify updating template in registry', () => {
         });
     });
 
+    test('Verify that adobeRecommended flag is not updated after creation', async () => {
+        const existingRegistryItem = generateRegistryItem(npmPackageName);
+        existingRegistryItem['adobeRecommended'] = false
+        existingRegistryItem['status'] = TEMPLATE_STATUS_IN_VERIFICATION
+        getFromRegistry.mockReturnValue(existingRegistryItem);
+        updateInRegistry.mockImplementation((item) => {
+            expect(item).toEqual({
+                'id': existingRegistryItem.id,
+                'name': existingRegistryItem.name,
+                'status': TEMPLATE_STATUS_APPROVED,
+                'links': existingRegistryItem.links,
+                'author': 'Adobe Inc.',
+                'description': 'A template for testing purposes [1.0.1]',
+                'latestVersion': '1.0.1',
+                'publishDate': existingRegistryItem.publishDate,
+                'extensions': [{ 'extensionPointId': 'dx/excshell/1' }],
+                'categories': ['action', 'ui'],
+                'runtime': true,
+                'apis': [
+                    { 'code': 'AnalyticsSDK', 'credentials': 'OAuth' },
+                    { 'code': 'CampaignStandard' },
+                    { 'code': 'Runtime' }
+                ],
+                'event': existingRegistryItem.event,
+                'adobeRecommended': false,
+                'keywords': ['aio', 'adobeio', 'app', 'templates', 'aio-app-builder-template']
+            });
+        });
+
+        const script = '../src/update-template.js';
+        process.argv = ['node', script, 'tests/templatePackage', gitHubUrl, npmPackageName, TEMPLATE_STATUS_APPROVED];
+        jest.isolateModules(async () => {
+            await require(script);
+        });
+    });
+
     test('Verify that "update-template.js" sets publishDate if missing', async () => {
         const newRegistryItemAddedViaAPI = {
             'id': 'some-id',
@@ -105,7 +141,6 @@ describe('Verify updating template in registry', () => {
         const gitHubUrl = 'https://github.com/company1/app-builder-template';
         const npmPackageName = '@company1/app-builder-template';
         const existingRegistryItem = generateRegistryItem(npmPackageName);
-        existingRegistryItem['adobeRecommended'] = false
         getFromRegistry.mockReturnValue(existingRegistryItem);
         updateInRegistry.mockImplementation((item) => {
             expect(item).toEqual({
@@ -118,7 +153,7 @@ describe('Verify updating template in registry', () => {
                 'latestVersion': '1.0.1',
                 'publishDate': existingRegistryItem.publishDate,
                 'categories': ['action', 'ui'],
-                'adobeRecommended': false,
+                'adobeRecommended': true,
                 'keywords': ['aio', 'adobeio', 'app', 'templates', 'aio-app-builder-template']
             });
         });

--- a/tests/update-template.test.js
+++ b/tests/update-template.test.js
@@ -25,7 +25,6 @@ beforeEach(() => {
 describe('Verify updating template in registry', () => {
     test('Verify that "update-template.js" updates template', async () => {
         const existingRegistryItem = generateRegistryItem(npmPackageName);
-        existingRegistryItem['adobeRecommended'] = true
         getFromRegistry.mockReturnValue(existingRegistryItem);
         updateInRegistry.mockImplementation((item) => {
             expect(item).toEqual({

--- a/tests/update-template.test.js
+++ b/tests/update-template.test.js
@@ -25,6 +25,7 @@ beforeEach(() => {
 describe('Verify updating template in registry', () => {
     test('Verify that "update-template.js" updates template', async () => {
         const existingRegistryItem = generateRegistryItem(npmPackageName);
+        existingRegistryItem['adobeRecommended'] = true
         getFromRegistry.mockReturnValue(existingRegistryItem);
         updateInRegistry.mockImplementation((item) => {
             expect(item).toEqual({
@@ -81,7 +82,6 @@ describe('Verify updating template in registry', () => {
                 'description': 'A template for testing purposes [1.0.1]',
                 'latestVersion': '1.0.1',
                 'categories': ['action', 'ui'],
-                'adobeRecommended': true,
                 'keywords': ['aio', 'adobeio', 'app', 'templates', 'aio-app-builder-template'],
                 'extensions': [{ 'extensionPointId': 'dx/excshell/1' }],
                 'apis': [
@@ -106,6 +106,7 @@ describe('Verify updating template in registry', () => {
         const gitHubUrl = 'https://github.com/company1/app-builder-template';
         const npmPackageName = '@company1/app-builder-template';
         const existingRegistryItem = generateRegistryItem(npmPackageName);
+        existingRegistryItem['adobeRecommended'] = false
         getFromRegistry.mockReturnValue(existingRegistryItem);
         updateInRegistry.mockImplementation((item) => {
             expect(item).toEqual({


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

The schedule template registry verification jobs call the update-template workflow, which call the isAdobeRecommended function again and set the adobeRecommended flag to that. In reality, it's not strictly necessary for the update-template workflow to set the adobeRecommended flag since it's a reasonable assumption that this flag (if not manually updated) won't change after the template is created. So the add-template workflow will set the adobeRecommended flag, an admin can manually update the flag for a beta template, and the update-template and scheduled verification jobs won't override the updated adobeRecommended flag. 

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

`npm run test`

https://github.com/devx-services/aio-template-submission/issues/131

This update-template issue did not override the adobeRecommended flag (which was false) of @adobe/aem-cf-admin-ui-ext-tpl.

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
