### PR TITLE
SITES-10416: Template registry workflow didn't indicate failure

### DIFF
--- a/.github/workflows/validate-template-workflow.yml
+++ b/.github/workflows/validate-template-workflow.yml
@@ -39,7 +39,6 @@ jobs:
   check-github-link:
     name: Check GitHub link
     runs-on: ubuntu-latest
-    continue-on-error: true
     outputs:
       error: ${{ steps.check-github-link.outputs.ERROR }}
       status: ${{ steps.check-github-link.outputs.STATUS }}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

SITES-10416: Template registry workflow didn't indicate failure

## Motivation and Context

One of the jobs of the Update workflow [0] failed for the Update Request [1].

**Expected result**
Workflow fails and the template is not added to the registry

**Actual result**
Workflow passed and the template was added to the registry

[0] https://github.com/adobe/aio-template-submission/actions/runs/3731395805/jobs/6329592256

[1] https://github.com/adobe/aio-template-submission/issues/466

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
