### PR TITLE
Fix is-admin.js edge cases: whitespace trimming and undefined ALLOWLIST_ADMINS

### DIFF
--- a/src/is-admin.js
+++ b/src/is-admin.js
@@ -11,11 +11,13 @@ governing permissions and limitations under the License.
 
 const core = require('@actions/core');
 
-const admins = process.env.ALLOWLIST_ADMINS.split(',');
+const allowlistAdmins = process.env.ALLOWLIST_ADMINS;
 const myArgs = process.argv.slice(2);
 const userLogin = myArgs[0];
 
-if (admins.includes(userLogin)) {
+if (!allowlistAdmins) {
+  core.setOutput('error', ':x: ALLOWLIST_ADMINS is not configured. No users are authorized to perform this action.');
+} else if (allowlistAdmins.split(',').map(s => s.trim()).filter(Boolean).includes(userLogin)) {
   core.setOutput('is-admin', 'true');
 } else {
   core.setOutput('error', ':x: Submitter is not an admin. Admins can remove and update any templates.');

--- a/tests/is-admin.test.js
+++ b/tests/is-admin.test.js
@@ -15,14 +15,14 @@ jest.mock('@actions/core');
 
 beforeEach(() => {
     jest.clearAllMocks();
+    process.env.ALLOWLIST_ADMINS = 'github-user-1,github-user-2';
 });
 
-process.env.ALLOWLIST_ADMINS = 'github-user-1,github-user-2';
+const script = '../src/is-admin.js';
 
 describe('Verify invoking is-admin.js', () => {
     test('A user is an admin', () => {
         const userLogin = 'github-user-1';
-        const script = '../src/is-admin.js';
         process.argv = ['node', script, userLogin];
         jest.isolateModules(() => {
             require(script);
@@ -32,11 +32,40 @@ describe('Verify invoking is-admin.js', () => {
 
     test('A user is not an admin', () => {
         const userLogin = 'non-admin-github-user';
-        const script = '../src/is-admin.js';
         process.argv = ['node', script, userLogin];
         jest.isolateModules(() => {
             require(script);
         });
         expect(core.setOutput).toHaveBeenCalledWith('error', ':x: Submitter is not an admin. Admins can remove and update any templates.');
+    });
+
+    test('Handles whitespace in ALLOWLIST_ADMINS', () => {
+        process.env.ALLOWLIST_ADMINS = 'github-user-1, github-user-2 , github-user-3';
+        const userLogin = 'github-user-2';
+        process.argv = ['node', script, userLogin];
+        jest.isolateModules(() => {
+            require(script);
+        });
+        expect(core.setOutput).toHaveBeenCalledWith('is-admin', 'true');
+    });
+
+    test('Handles undefined ALLOWLIST_ADMINS', () => {
+        delete process.env.ALLOWLIST_ADMINS;
+        const userLogin = 'github-user-1';
+        process.argv = ['node', script, userLogin];
+        jest.isolateModules(() => {
+            require(script);
+        });
+        expect(core.setOutput).toHaveBeenCalledWith('error', ':x: ALLOWLIST_ADMINS is not configured. No users are authorized to perform this action.');
+    });
+
+    test('Handles empty ALLOWLIST_ADMINS', () => {
+        process.env.ALLOWLIST_ADMINS = '';
+        const userLogin = 'github-user-1';
+        process.argv = ['node', script, userLogin];
+        jest.isolateModules(() => {
+            require(script);
+        });
+        expect(core.setOutput).toHaveBeenCalledWith('error', ':x: ALLOWLIST_ADMINS is not configured. No users are authorized to perform this action.');
     });
 });


### PR DESCRIPTION
## Summary

- Trim whitespace from `ALLOWLIST_ADMINS` entries after `split(',')` so values like `"user1, user2"` correctly match `"user2"`
- Handle undefined/empty `ALLOWLIST_ADMINS` gracefully with a clear error message instead of throwing `TypeError`
- Add 3 new test cases covering whitespace, undefined, and empty edge cases

## Test plan

- [x] Run `npm test` — all 5 tests in `tests/is-admin.test.js` pass
- [x] Verify `ALLOWLIST_ADMINS` with spaces (e.g., `user1, user2`) still recognizes all admins
- [x] Verify missing/empty `ALLOWLIST_ADMINS` produces error output instead of crash

🤖 Generated with [Claude Code](https://claude.com/claude-code)